### PR TITLE
Use getPath('appData') + getName() instead of getPath('userData')

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ const Conf = require('conf');
 
 class ElectronStore extends Conf {
 	constructor(opts) {
-		const defaultCwd = (electron.app || electron.remote.app).getPath('userData');
+		const app = electron.app || electron.remote.app;
+		const defaultCwd = path.join(app.getPath('appData'), app.getName());
 
 		opts = Object.assign({name: 'config'}, opts);
 


### PR DESCRIPTION
`(electron.app || electron.app.remote).getPath('userData')` was inconsistent for me, in this module and a config solution of my own, in the main process giving me `~/.config/<appname>` and in the renderer giving me `~/.config/Electron`. I've found that `path.join`ing `app.getPath('appData')` and `app.getName()` works in both, and is purportedly what `app.getPath('userData')` does in the first place; [electron docs](https://github.com/electron/electron/blob/master/docs/api/app.md#appgetpathname).