### PR TITLE
Fix deprecated `crypto.createDecipher()` and `crypto.createCipher()` Node.js warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"save"
 	],
 	"dependencies": {
-		"conf": "^4.1.0",
+		"conf": "^5.0.0",
 		"type-fest": "^0.3.1"
 	},
 	"devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -119,9 +119,9 @@ If a relative path, it's relative to the default cwd. For example, `{cwd: 'unico
 Type: `string` `Buffer` `TypedArray` `DataView`<br>
 Default: `undefined`
 
-Note that this is **not intended for security purposes**, since the encryption key would be easily found inside a plain-text Electron app.
+This can be used to secure sensitive data **if** the encryption key is stored in a secure manner (not plain-text) in the Node.js app. For example, by using [`node-keytar`](https://github.com/atom/node-keytar) to store the encryption key securely, or asking the encryption key from the user (a password) and then storing it in a variable.
 
-Its main use is for obscurity. If a user looks through the config directory and finds the config file, since it's just a JSON file, they may be tempted to modify it. By providing an encryption key, the file will be obfuscated, which should hopefully deter any users from doing so.
+In addition to security, this could be used for obscurity. If a user looks through the config directory and finds the config file, since it's just a JSON file, they may be tempted to modify it. By providing an encryption key, the file will be obfuscated, which should hopefully deter any users from doing so.
 
 It also has the added bonus of ensuring the config file's integrity. If the file is changed in any way, the decryption will not work, in which case the store will just reset back to its default state.
 


### PR DESCRIPTION
Fix #67