### PR TITLE
Improve Electron 9 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ class ElectronStore extends Conf {
 	}
 
 	openInEditor() {
-		electron.shell.openItem(this.path);
+		const open = electron.shell.openItem || electron.shell.openPath;
+		open(this.path);
 	}
 }
 


### PR DESCRIPTION
This fixes #117 and supports opening the config in both older and newer versions of electron.