### PR TITLE
Fix defaultCwd for electron@10 

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,13 @@ const Conf = require('conf');
 
 class ElectronStore extends Conf {
 	constructor(options) {
-		const defaultCwd = (electron.app || electron.remote.app).getPath('userData');
+		let defaultCwd = path.join(__dirname, '..');
+
+		try {
+			defaultCwd = (electron.app || electron.remote.app).getPath('userData');
+		} catch (error) {
+			console.error(error);
+		}
 
 		options = {
 			name: 'config',


### PR DESCRIPTION
In 10th version electron are going to remove `remote` as they considered it harmful. So I suggest to provide try-catch block in order to prevent library crash.