### PR TITLE
Ability to use Electron Store without exposing the entire Electron API or exposing the remote module

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const Conf = require('conf');
 
 class ElectronStore extends Conf {
 	constructor(options) {
-		const app = (electron.app || app || electron.remote.app);
+		const app = (app || electron.app || electron.remote.app);
 		const defaultCwd = app.getPath('userData');
 
 		options = {

--- a/index.js
+++ b/index.js
@@ -1,11 +1,10 @@
 'use strict';
 const path = require('path');
-const electron = require('electron');
 const Conf = require('conf');
 
 class ElectronStore extends Conf {
 	constructor(options) {
-		const app = (electron.app || electron.remote.app);
+		const app = (electron.app || app || electron.remote.app);
 		const defaultCwd = app.getPath('userData');
 
 		options = {
@@ -30,7 +29,8 @@ class ElectronStore extends Conf {
 
 	openInEditor() {
 		// TODO: Remove `electron.shell.openItem` when targeting Electron 9.`
-		const open = electron.shell.openItem || electron.shell.openPath;
+		const shell = shell
+		const open = (shell.openItem || shell.openPath) || (electron.shell.openItem || electron.shell.openPath);
 		open(this.path);
 	}
 }


### PR DESCRIPTION
This PR lets you define both app and shell in your preload.js without having to expose the entire electron API or enabling the remote module.
