### PR TITLE
Fix: projectVersion type should not be excluded

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ import Conf, {Schema as ConfSchema, Options as ConfOptions} from 'conf';
 declare namespace ElectronStore {
 	type Schema<T> = ConfSchema<T>;
 
-	type Options<T> = Except<ConfOptions<T>, 'configName' | 'projectName' | 'projectVersion' | 'projectSuffix'> & {
+	type Options<T> = Except<ConfOptions<T>, 'configName' | 'projectName' | 'projectSuffix'> & {
 		/**
 		Name of the storage file (without extension).
 


### PR DESCRIPTION
Project version is used for the migration feature and should be included in the options