### PR TITLE
Fix the internal IPC to only subscribe to events once

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const {app, ipcMain, ipcRenderer, shell} = require('electron');
 const Conf = require('conf');
-const flags = {initalised: false};
+let isInitialised = false;
 
 // Set up the `ipcMain` handler for communication between renderer and main process.
 const initDataListener = () => {
@@ -14,13 +14,14 @@ const initDataListener = () => {
 		defaultCwd: app.getPath('userData'),
 		appVersion: app.getVersion()
 	};
+	
+	if (isInitialised) return appData;
 
-	if (!flags.initialised) {
-		ipcMain.on('electron-store-get-data', event => {
-			event.returnValue = appData;
-		});
-		flags.initialised = true;
-	}
+	ipcMain.on('electron-store-get-data', event => {
+		event.returnValue = appData;
+	});
+	
+	isInitialised = true;
 
 	return appData;
 };

--- a/index.js
+++ b/index.js
@@ -14,13 +14,13 @@ const initDataListener = () => {
 		defaultCwd: app.getPath('userData'),
 		appVersion: app.getVersion()
 	};
-	
+
 	if (isInitialised) return appData;
 
 	ipcMain.on('electron-store-get-data', event => {
 		event.returnValue = appData;
 	});
-	
+
 	isInitialised = true;
 
 	return appData;

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const path = require('path');
 const {app, ipcMain, ipcRenderer, shell} = require('electron');
 const Conf = require('conf');
+const flags = {initalised: false};
 
 // Set up the `ipcMain` handler for communication between renderer and main process.
 const initDataListener = () => {
@@ -14,9 +15,12 @@ const initDataListener = () => {
 		appVersion: app.getVersion()
 	};
 
-	ipcMain.on('electron-store-get-data', event => {
-		event.returnValue = appData;
-	});
+	if (!flags.initialised) {
+		ipcMain.on('electron-store-get-data', event => {
+			event.returnValue = appData;
+		});
+		flags.initialised = true;
+	}
 
 	return appData;
 };

--- a/index.js
+++ b/index.js
@@ -15,8 +15,10 @@ const initDataListener = () => {
 		appVersion: app.getVersion()
 	};
 
-	if (isInitialised) return appData;
-
+	if (isInitialised) {
+		return appData;
+	}
+	
 	ipcMain.on('electron-store-get-data', event => {
 		event.returnValue = appData;
 	});

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const initDataListener = () => {
 	if (isInitialised) {
 		return appData;
 	}
-	
+
 	ipcMain.on('electron-store-get-data', event => {
 		event.returnValue = appData;
 	});

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const initDataListener = () => {
 		appVersion: app.getVersion()
 	};
 
-	if (isInitialised) {
+	if (isInitialized) {
 		return appData;
 	}
 
@@ -24,7 +24,7 @@ const initDataListener = () => {
 		event.returnValue = appData;
 	});
 
-	isInitialised = true;
+	isInitialized = true;
 
 	return appData;
 };

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
 const path = require('path');
 const {app, ipcMain, ipcRenderer, shell} = require('electron');
 const Conf = require('conf');
-let isInitialised = false;
+
+let isInitialized = false;
 
 // Set up the `ipcMain` handler for communication between renderer and main process.
 const initDataListener = () => {


### PR DESCRIPTION
On each construction of an ElectronStore instance, the initDataListener method is called. This causes duplicate ipcMain handlers for the 'electron-store-get-data' channel. Found that this causes an Electron EventEmitter warning of 'MaxListenersExceededWarning'. By setting an initialiser flag, events are handled as needed and does not cause this warning. Additionally if someone were to properly exceed this (in my case I was at 11), by dynamically creating larger amounts of stores (which could be possible in larger scale applications, although not recommended), this could have dangerous and odd side-effects.