### PR TITLE
Update Options type parameter constraint for TS 4.7

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ import Conf, {Schema as ConfSchema, Options as ConfOptions} from 'conf';
 declare namespace ElectronStore {
 	type Schema<T> = ConfSchema<T>;
 
-	type Options<T> = Except<ConfOptions<T>, 'configName' | 'projectName' | 'projectVersion' | 'projectSuffix'> & {
+	type Options<T extends Record<string, any>> = Except<ConfOptions<T>, 'configName' | 'projectName' | 'projectVersion' | 'projectSuffix'> & {
 		/**
 		Name of the storage file (without extension).
 

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
 		"save"
 	],
 	"dependencies": {
-		"conf": "^10.0.3",
-		"type-fest": "^1.0.2"
+		"conf": "^10.1.2",
+		"type-fest": "^2.12.2"
 	},
 	"devDependencies": {
 		"ava": "^2.4.0",


### PR DESCRIPTION
Options's type parameter is passed to conf's Options type, which
requires is constrained to `Record<string, any>`. Typescript 4.7 will
properly check this constraint where it didn't before.

Fixes #222

Depends on fixes: sindresorhus/type-fest#388 and sindresorhus/conf#163