### PR TITLE
Return value of `shell.openPath` in `openInEditor`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,6 +59,8 @@ declare class ElectronStore<T extends Record<string, any> = Record<string, unkno
 
 	/**
 	Open the storage file in the user's editor.
+
+ 	Returns a promise that resolves when the editor has been opened, or rejects if it failed to open.
 	*/
 	openInEditor(): Promise<void>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,7 +60,7 @@ declare class ElectronStore<T extends Record<string, any> = Record<string, unkno
 	/**
 	Open the storage file in the user's editor.
 	*/
-	openInEditor(): void;
+	openInEditor(): Promise<string>;
 }
 
 export = ElectronStore;

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,7 +60,7 @@ declare class ElectronStore<T extends Record<string, any> = Record<string, unkno
 	/**
 	Open the storage file in the user's editor.
 	*/
-	openInEditor(): Promise<string>;
+	openInEditor(): Promise<void>;
 }
 
 export = ElectronStore;

--- a/index.js
+++ b/index.js
@@ -73,8 +73,12 @@ class ElectronStore extends Conf {
 		initDataListener();
 	}
 
-	openInEditor() {
-		return shell.openPath(this.path);
+	async openInEditor() {
+		const error = await shell.openPath(this.path);
+
+		if (error) {
+			throw new Error(error);
+		}
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ class ElectronStore extends Conf {
 	}
 
 	openInEditor() {
-		shell.openPath(this.path);
+		return shell.openPath(this.path);
 	}
 }
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -18,7 +18,7 @@ store.reset('foo');
 store.has('foo');
 store.clear();
 
-store.openInEditor();
+await store.openInEditor();
 
 store.size; // eslint-disable-line @typescript-eslint/no-unused-expressions
 store.store; // eslint-disable-line @typescript-eslint/no-unused-expressions

--- a/readme.md
+++ b/readme.md
@@ -379,7 +379,7 @@ Get the path to the storage file.
 
 Open the storage file in the user's editor.
 
-Will throw if the file failed to open.
+Returns a promise that resolves when the editor has been opened, and rejects if it failed to open.
 
 ### initRenderer()
 

--- a/readme.md
+++ b/readme.md
@@ -375,11 +375,11 @@ store.store = {
 
 Get the path to the storage file.
 
-#### async .openInEditor()
+#### .openInEditor()
 
 Open the storage file in the user's editor.
 
-Returns a promise that resolves when the editor has been opened, and rejects if it failed to open.
+Returns a promise that resolves when the editor has been opened, or rejects if it failed to open.
 
 ### initRenderer()
 

--- a/readme.md
+++ b/readme.md
@@ -379,7 +379,7 @@ Get the path to the storage file.
 
 Open the storage file in the user's editor.
 
-See [`electron.shell.openPath(path)`](https://www.electronjs.org/docs/latest/api/shell#shellopenpathpath) for handling return value.
+Will throw if the file failed to open.
 
 ### initRenderer()
 

--- a/readme.md
+++ b/readme.md
@@ -375,9 +375,11 @@ store.store = {
 
 Get the path to the storage file.
 
-#### .openInEditor()
+#### async .openInEditor()
 
 Open the storage file in the user's editor.
+
+See [`electron.shell.openPath(path)`](https://www.electronjs.org/docs/latest/api/shell#shellopenpathpath) for handling return value.
 
 ### initRenderer()
 


### PR DESCRIPTION
### Summary
This PR returns the value of `shell.openPath()` in the `openInEditor` method

### Motivation
If someone needs to perform an action only after the path has been opened, there's currently no way to do that, since the async `shell.openPath()` call isn't waited on, or return value passed through.

### Use Case
My specific use case was wanting to quit the app after using this method to open a invalid (not matching the schema) config file. And without the return value I had to use `shell.openPath()` directly so I could `await` it.